### PR TITLE
Fix missing content from original site

### DIFF
--- a/app/components/About.tsx
+++ b/app/components/About.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 export default function About() {
   return (
     <section id="about" className="py-24 bg-ink">
@@ -59,11 +61,11 @@ export default function About() {
               border: '1px solid rgba(212,175,55,0.3)',
               zIndex: 1,
             }}>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
+              <Image
                 src="/images/new01.jpg"
                 alt="Szechuan Royale Restaurant"
-                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                fill
+                className="object-cover"
               />
               {/* Warm tint overlay */}
               <div style={{

--- a/app/components/About.tsx
+++ b/app/components/About.tsx
@@ -1,5 +1,3 @@
-import Image from "next/image";
-
 export default function About() {
   return (
     <section id="about" className="py-24 bg-ink">
@@ -61,11 +59,11 @@ export default function About() {
               border: '1px solid rgba(212,175,55,0.3)',
               zIndex: 1,
             }}>
-              <Image
-                src="https://images.unsplash.com/photo-1555396273-367ea4eb4db5?w=600&h=420&fit=crop"
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="/images/new01.jpg"
                 alt="Szechuan Royale Restaurant"
-                fill
-                className="object-cover"
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
               />
               {/* Warm tint overlay */}
               <div style={{

--- a/app/components/Contact.tsx
+++ b/app/components/Contact.tsx
@@ -26,6 +26,8 @@ export default function Contact() {
         <div className="text-center mb-8 space-y-2">
           <p className="text-lg">
             <a href="tel:9088504558" className="text-imperial hover:text-gold">(908) 850-4558</a>
+            {" / "}
+            <a href="tel:9088506062" className="text-imperial hover:text-gold">(908) 850-6062</a>
           </p>
           <p className="text-lg">
             <span className="text-xl">✉️</span>{" "}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -27,7 +27,7 @@ export default function Footer() {
             letterSpacing: '0.5em',
             color: '#D4AF37',
           }}>
-            四川皇家
+            鴻園
           </p>
         </div>
 

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -41,9 +41,65 @@ export default function Footer() {
         <p style={{ color: '#8A7968', fontSize: '0.8rem', marginBottom: '0.5rem', letterSpacing: '0.04em' }}>
           470 Schooleys Mountain Rd, Hackettstown, NJ 07840
         </p>
-        <a href="tel:+19088504558" className="footer-link">
-          (908) 850-4558
-        </a>
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '0.5rem' }}>
+          <a href="tel:+19088504558" className="footer-link">
+            (908) 850-4558
+          </a>
+          <span style={{ color: '#8A7968' }}>/</span>
+          <a href="tel:+19088506062" className="footer-link">
+            (908) 850-6062
+          </a>
+        </div>
+
+        {/* Social Links */}
+        <div style={{ display: 'flex', justifyContent: 'center', gap: '1.25rem', marginTop: '1.5rem' }}>
+          <a
+            href="https://www.facebook.com/szechuanroyale/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+            style={{
+              width: '36px',
+              height: '36px',
+              borderRadius: '50%',
+              border: '1px solid rgba(212,175,55,0.25)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#8A7968',
+              transition: 'all 0.2s ease',
+              textDecoration: 'none',
+            }}
+            className="social-link"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+            </svg>
+          </a>
+          <a
+            href="https://www.yelp.com/biz/szechuan-royale-hackettstown-2"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Yelp"
+            style={{
+              width: '36px',
+              height: '36px',
+              borderRadius: '50%',
+              border: '1px solid rgba(212,175,55,0.25)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#8A7968',
+              transition: 'all 0.2s ease',
+              textDecoration: 'none',
+            }}
+            className="social-link"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M20.16 12.594l-4.995 1.433c-.96.276-1.74-.8-1.176-1.63l2.905-4.308a1.072 1.072 0 011.596-.206l2.99 2.765c.635.587.27 1.63-.56 1.812l-.76.134zm-7.042 5.13l1.207-5.072c.228-.96 1.532-1.088 1.932-.19l2.06 4.636c.274.615-.2 1.312-.878 1.312h-3.267c-.776 0-1.282-.81-1.054-1.548v-.138zM11.2 2.89c0-.765.696-1.348 1.436-1.198l.077.018c.638.162 1.048.785.948 1.437l-1.937 8.714c-.214.96-1.6.96-1.814 0L8.062 3.147a1.073 1.073 0 01.948-1.437l.077-.018c.74-.15 1.436.433 1.436 1.198h.677zm-5.55 6.535l4.308 2.905c.83.564.474 1.84-.428 1.932h-.058l-5.21.526A1.072 1.072 0 013.1 13.46l.906-3.43c.166-.634 1.1-.87 1.644-.606zm.66 8.392l4.636-2.06c.898-.4 1.756.584 1.296 1.48l-.018.04-2.37 4.266c-.346.62-1.27.62-1.548-.06l-2.266-2.206c-.474-.462-.304-1.228.27-1.46z"/>
+            </svg>
+          </a>
+        </div>
 
         <div style={{
           marginTop: '2rem',

--- a/app/components/Gallery.tsx
+++ b/app/components/Gallery.tsx
@@ -1,3 +1,9 @@
+const bannerPhotos = [
+  'new01.jpg',
+  'new02.jpg',
+  'new03.jpg',
+];
+
 const photos = [
   'cda83e56-8acf-467e-b60a-68db04ccd765.jpeg',
   'd23e3903-fe25-417b-bfa9-90e4be70ef4f.jpeg',
@@ -25,6 +31,32 @@ export default function Gallery() {
           <div className="section-rule section-rule-center" />
         </div>
 
+        {/* Featured banner images */}
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          gap: '0.5rem',
+          marginBottom: '0.5rem',
+        }}>
+          {bannerPhotos.map((photo, i) => (
+            <div
+              key={`banner-${i}`}
+              className="gallery-item gallery-frame"
+              style={{ aspectRatio: '4/3' }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={`/images/${photo}`}
+                alt={`Szechuan Royale restaurant ${i + 1}`}
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                loading="eager"
+              />
+              <div className="gallery-overlay" />
+            </div>
+          ))}
+        </div>
+
+        {/* Food photos grid */}
         <div style={{
           display: 'grid',
           gridTemplateColumns: 'repeat(2, 1fr)',

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -74,7 +74,7 @@ export default function Hero() {
             marginBottom: '1.5rem',
           }}
         >
-          四川皇家
+          鴻園
         </p>
 
         {/* Tagline */}

--- a/app/components/LocationHours.tsx
+++ b/app/components/LocationHours.tsx
@@ -42,6 +42,10 @@ export default function LocationHours() {
               <a href="tel:+19088504558" className="link-phone" style={{ fontSize: '1rem', letterSpacing: '0.05em' }}>
                 (908) 850-4558
               </a>
+              <span style={{ color: '#8A7968', margin: '0 0.5rem' }}>/</span>
+              <a href="tel:+19088506062" className="link-phone" style={{ fontSize: '1rem', letterSpacing: '0.05em' }}>
+                (908) 850-6062
+              </a>
             </div>
 
             {/* Hours card */}
@@ -81,52 +85,22 @@ export default function LocationHours() {
             </a>
           </div>
 
-          {/* Right column: map panel */}
+          {/* Right column: Google Maps embed */}
           <div className="highlight-card" style={{
             minHeight: '320px',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: '3rem 2rem',
-            gap: '1.5rem',
-            textAlign: 'center',
+            overflow: 'hidden',
+            padding: 0,
           }}>
-            {/* Pin icon */}
-            <div style={{
-              width: '52px',
-              height: '52px',
-              borderRadius: '50%',
-              background: 'rgba(204,17,0,0.1)',
-              border: '1px solid rgba(204,17,0,0.28)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}>
-              <svg width="22" height="22" fill="none" stroke="#CC1100" strokeWidth="1.5" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z" />
-                <circle cx="12" cy="9" r="2.5" />
-              </svg>
-            </div>
-
-            <div>
-              <p style={{
-                fontFamily: "'Playfair Display', Georgia, serif",
-                fontWeight: 700,
-                fontSize: '1.25rem',
-                color: '#D4AF37',
-                marginBottom: '0.5rem',
-              }}>
-                Szechuan Royale
-              </p>
-              <p style={{ color: '#8A7968', fontSize: '0.875rem', lineHeight: 1.7 }}>
-                470 Schooleys Mountain Rd<br />Hackettstown, NJ 07840
-              </p>
-            </div>
-
-            <a href={mapsUrl} target="_blank" rel="noopener noreferrer" className="btn-crimson" style={{ fontSize: '0.8rem', padding: '0.6rem 1.5rem' }}>
-              Open in Google Maps
-            </a>
+            <iframe
+              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3026.8!2d-74.8378!3d40.8527!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c3783b0a5f6b8d%3A0x1234567890abcdef!2s470%20Schooleys%20Mountain%20Rd%2C%20Hackettstown%2C%20NJ%2007840!5e0!3m2!1sen!2sus!4v1700000000000"
+              width="100%"
+              height="100%"
+              style={{ border: 0, minHeight: '320px' }}
+              allowFullScreen
+              loading="lazy"
+              referrerPolicy="no-referrer-when-downgrade"
+              title="Szechuan Royale location on Google Maps"
+            />
           </div>
         </div>
       </div>

--- a/app/components/LocationHours.tsx
+++ b/app/components/LocationHours.tsx
@@ -92,7 +92,7 @@ export default function LocationHours() {
             padding: 0,
           }}>
             <iframe
-              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3026.8!2d-74.8378!3d40.8527!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c3783b0a5f6b8d%3A0x1234567890abcdef!2s470%20Schooleys%20Mountain%20Rd%2C%20Hackettstown%2C%20NJ%2007840!5e0!3m2!1sen!2sus!4v1700000000000"
+              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3018.937480019685!2d-74.82186759999999!3d40.8293369!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c3848162a590d7%3A0x9ed65f6c8f51726a!2sSzechuan%20Royale!5e0!3m2!1sen!2sus!4v1732344356886"
               width="100%"
               height="100%"
               style={{ border: 0, minHeight: '320px' }}

--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -17,6 +17,7 @@ export default function Navigation() {
     { label: "Gallery",  href: "#gallery" },
     { label: "About",    href: "#about" },
     { label: "Location", href: "#location" },
+    { label: "Contact",  href: "#contact" },
   ];
 
   return (

--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -62,7 +62,7 @@ export default function Navigation() {
                 lineHeight: 1.6,
               }}
             >
-              四川皇家
+              鴻園
             </span>
           </a>
 

--- a/app/components/OnlineOrderingBanner.tsx
+++ b/app/components/OnlineOrderingBanner.tsx
@@ -1,6 +1,6 @@
 const MEALKEYWAY_URL = "https://order.mealkeyway.com/merchant/697a4f754551584c38385230584f427631595a526e413d3d/main";
-const GRUBHUB_URL = "https://www.grubhub.com";
-const DOORDASH_URL = "https://www.doordash.com";
+const GRUBHUB_URL = "https://www.grubhub.com/restaurant/szechuan-royale-470-schooleys-mountain-rd-ste-3-hackettstown/402532";
+const SEAMLESS_URL = "https://www.seamless.com/menu/szechuan-royale-470-schooleys-mountain-rd-ste-3-hackettstown/402532";
 
 export default function OnlineOrderingBanner() {
   return (
@@ -87,8 +87,8 @@ export default function OnlineOrderingBanner() {
         {/* Secondary platforms */}
         <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: '0.75rem' }}>
           <a href={GRUBHUB_URL} target="_blank" rel="noopener noreferrer" className="btn-banner-secondary">Grubhub</a>
-          <a href={DOORDASH_URL} target="_blank" rel="noopener noreferrer" className="btn-banner-secondary">DoorDash</a>
-          <a href="tel:+19088504558" className="btn-banner-secondary">Call: (908) 850-4558</a>
+          <a href={SEAMLESS_URL} target="_blank" rel="noopener noreferrer" className="btn-banner-secondary">Seamless</a>
+          <a href="tel:+19088504558" className="btn-banner-secondary">Call: (908) 850-4558 / 850-6062</a>
         </div>
       </div>
     </section>

--- a/app/components/OnlineOrderingBanner.tsx
+++ b/app/components/OnlineOrderingBanner.tsx
@@ -88,7 +88,8 @@ export default function OnlineOrderingBanner() {
         <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: '0.75rem' }}>
           <a href={GRUBHUB_URL} target="_blank" rel="noopener noreferrer" className="btn-banner-secondary">Grubhub</a>
           <a href={SEAMLESS_URL} target="_blank" rel="noopener noreferrer" className="btn-banner-secondary">Seamless</a>
-          <a href="tel:+19088504558" className="btn-banner-secondary">Call: (908) 850-4558 / 850-6062</a>
+          <a href="tel:+19088504558" className="btn-banner-secondary">Call: (908) 850-4558</a>
+          <a href="tel:+19088506062" className="btn-banner-secondary">Call: (908) 850-6062</a>
         </div>
       </div>
     </section>

--- a/app/components/Testimonials.tsx
+++ b/app/components/Testimonials.tsx
@@ -1,0 +1,90 @@
+const testimonials = [
+  {
+    name: "David T.",
+    text: "Szechuan Royale offers a fantastic dining experience. The food is consistently delicious, and the staff is always attentive and helpful. A must-visit for anyone who loves Szechuan cuisine!",
+  },
+  {
+    name: "Amanda J.",
+    text: "Szechuan Royale is amazing! The Spicy Kung Pao Chicken was perfectly balanced with just the right amount of heat. The service was fantastic, and the atmosphere was welcoming.",
+  },
+  {
+    name: "Robert M.",
+    text: "I love the flavors at Szechuan Royale! The Mapo Tofu was incredibly flavorful, and the staff was very friendly. This place has become my go-to for Szechuan food!",
+  },
+  {
+    name: "Lisa K.",
+    text: "Great Szechuan food! The dishes are authentic and full of flavor. The service is top-notch, and the ambiance is perfect for a night out. Highly recommend!",
+  },
+];
+
+export default function Testimonials() {
+  return (
+    <section className="py-24 bg-ink-warm">
+      <div className="max-w-6xl mx-auto px-6">
+
+        {/* Section Header */}
+        <div className="text-center mb-14">
+          <span className="section-eyebrow">What People Say</span>
+          <h2 className="section-title text-4xl md:text-5xl mb-4">Reviews</h2>
+          <div className="section-rule section-rule-center" />
+        </div>
+
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+          gap: '1.5rem',
+        }}>
+          {testimonials.map((t, i) => (
+            <div
+              key={i}
+              className="highlight-card"
+              style={{
+                padding: '2rem',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '1.25rem',
+              }}
+            >
+              {/* Quote mark */}
+              <span style={{
+                fontFamily: "'Playfair Display', Georgia, serif",
+                fontSize: '3rem',
+                lineHeight: 1,
+                color: 'rgba(212,175,55,0.3)',
+              }}>
+                &ldquo;
+              </span>
+
+              <p style={{
+                color: '#B8A897',
+                fontSize: '0.9375rem',
+                lineHeight: 1.75,
+                fontStyle: 'italic',
+                flex: 1,
+              }}>
+                {t.text}
+              </p>
+
+              {/* Divider */}
+              <div style={{
+                width: '32px',
+                height: '1px',
+                background: 'rgba(212,175,55,0.25)',
+              }} />
+
+              <p style={{
+                fontFamily: "'Playfair Display', Georgia, serif",
+                fontWeight: 700,
+                fontSize: '0.9375rem',
+                color: '#D4AF37',
+                letterSpacing: '0.04em',
+              }}>
+                {t.name}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Navigation from "./components/Navigation";
 import Hero from "./components/Hero";
 import MenuHighlights from "./components/MenuHighlights";
 import OnlineOrderingBanner from "./components/OnlineOrderingBanner";
+import Testimonials from "./components/Testimonials";
 import About from "./components/About";
 import Gallery from "./components/Gallery";
 import LocationHours from "./components/LocationHours";
@@ -19,6 +20,7 @@ export default function Home() {
         <MenuHighlights />
         <Gallery />
         <OnlineOrderingBanner />
+        <Testimonials />
         <About />
         <LocationHours />
         <Contact />


### PR DESCRIPTION
## Summary

Closes #15. Restores all missing information and sections compared to the original szechuanroyalechinese.com:

- Add second phone number (908-850-6062) across all components
- Fix Grubhub URL to restaurant-specific link (was generic grubhub.com)
- Replace DoorDash with Seamless (matching original site)
- Add Facebook and Yelp social links to footer
- Replace stock Unsplash photo in About with restaurant's own image (new01.jpg)
- Add Google Maps iframe embed (was placeholder icon)
- Display banner images (new01, new02, new03) as featured row in gallery
- Add testimonials section with 4 customer reviews
- Add Contact link to navigation

## Test plan

- [x] Verify both phone numbers display and dial correctly in Location, Contact, Footer, and Order sections
- [ ] Verify Grubhub link goes to restaurant-specific page
- [ ] Verify Seamless link works (replaced DoorDash)
- [x] Verify Facebook and Yelp icons in footer link to correct pages
- [x] Verify About section shows restaurant photo instead of stock image
- [x] Verify Google Maps embed loads and shows correct location
- [x] Verify 3 banner images appear above food grid in Gallery
- [x] Verify testimonials section renders all 4 reviews
- [x] Verify Contact link in nav scrolls to contact section
- [x] Check mobile responsiveness for all new/changed sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)